### PR TITLE
fix: don't prompt on first-time setup

### DIFF
--- a/src/nexus/Freqlog/backends/SQLite/SQLiteBackend.py
+++ b/src/nexus/Freqlog/backends/SQLite/SQLiteBackend.py
@@ -72,7 +72,7 @@ class SQLiteBackend(Backend):
 
         # Encode major, minor and patch version into a single 4-byte integer
         sql_version: int = self.encode_version(__version__)
-        if old_version < sql_version:
+        if old_version < sql_version and old_version != 0:
             self._upgrade_database(self.decode_version(old_version))
         elif old_version > sql_version:
             raise ValueError(


### PR DESCRIPTION
The database version being 0 simply means that the user hasn't ever used the app yet. Don't prompt to upgrade in this scenario.