### PR TITLE
fix: incorrect logging message

### DIFF
--- a/src/nexus/Freqlog/backends/SQLite/SQLiteBackend.py
+++ b/src/nexus/Freqlog/backends/SQLite/SQLiteBackend.py
@@ -108,8 +108,7 @@ class SQLiteBackend(Backend):
         """
         if self.upgrade_callback:
             self.upgrade_callback(old_version)
-        logging.warning(f"Upgrading database from {self.decode_version(self._fetchone('PRAGMA user_version')[0])} to "
-                        f"{old_version}")
+        logging.warning(f"Upgrading database from {old_version} to {__version__}")
 
         # TODO: populate this function when changing DDL
 


### PR DESCRIPTION
When upgrading the database from version X to version Y, the logger simply displays `Upgrading database from X to X` since `old_version` and the `fetchone` from the existing DB return the same thing. This is a logical error.