### PR TITLE
Undo changes to translation file

### DIFF
--- a/translations/i18n_ro.ts
+++ b/translations/i18n_ro.ts
@@ -6,29 +6,30 @@
     <message>
         <location filename="../ui/BanlistDialog.ui" line="14"/>
         <source>Banlist</source>
-        <translation type="unfinished">Listă interziceri</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ui/BanlistDialog.ui" line="46"/>
+        <location filename="../ui/BanlistDialog.ui" line="39"/>
         <source>Word</source>
         <translation>Cuvânt</translation>
     </message>
     <message>
-        <location filename="../ui/BanlistDialog.ui" line="51"/>
+        <location filename="../ui/BanlistDialog.ui" line="44"/>
         <source>Date added</source>
         <translation>Dată adăugare</translation>
     </message>
     <message>
+        <location filename="../ui/BanlistDialog.ui" line="49"/>
         <source>Case</source>
-        <translation type="vanished">Majuscule</translation>
+        <translation>Majuscule</translation>
     </message>
     <message>
-        <location filename="../ui/BanlistDialog.ui" line="64"/>
+        <location filename="../ui/BanlistDialog.ui" line="62"/>
         <source>Add</source>
         <translation>Adaugă</translation>
     </message>
     <message>
-        <location filename="../ui/BanlistDialog.ui" line="71"/>
+        <location filename="../ui/BanlistDialog.ui" line="69"/>
         <source>Remove</source>
         <translation>Scoate</translation>
     </message>
@@ -36,419 +37,34 @@
 <context>
     <name>BanwordDialog</name>
     <message>
+        <location filename="../ui/BanwordDialog.ui" line="17"/>
         <source>Ban word</source>
-        <translation type="vanished">Interzice cuvânt</translation>
+        <translation>Interzice cuvânt</translation>
     </message>
     <message>
+        <location filename="../ui/BanwordDialog.ui" line="25"/>
         <source>Word to ban:</source>
-        <translation type="vanished">Cuvinte pentru interzicere:</translation>
+        <translation>Cuvinte pentru interzicere:</translation>
     </message>
     <message>
+        <location filename="../ui/BanwordDialog.ui" line="39"/>
         <source>Case:</source>
-        <translation type="vanished">Majuscule:</translation>
+        <translation>Majuscule:</translation>
     </message>
     <message>
+        <location filename="../ui/BanwordDialog.ui" line="46"/>
         <source>Insensitive</source>
-        <translation type="vanished">Insensibil</translation>
+        <translation>Insensibil</translation>
     </message>
     <message>
+        <location filename="../ui/BanwordDialog.ui" line="56"/>
         <source>Sensitive</source>
-        <translation type="vanished">Sensibil</translation>
+        <translation>Sensibil</translation>
     </message>
     <message>
+        <location filename="../ui/BanwordDialog.ui" line="63"/>
         <source>First char</source>
-        <translation type="vanished">Primul caracter</translation>
-    </message>
-</context>
-<context>
-    <name>GUI</name>
-    <message>
-        <source>Start logging</source>
-        <translation type="vanished">Începe înregistrarea</translation>
-    </message>
-    <message>
-        <source>Starting...</source>
-        <translation type="vanished">Se începe...</translation>
-    </message>
-    <message>
-        <source>Stop logging</source>
-        <translation type="vanished">Oprește înregistrarea...</translation>
-    </message>
-    <message>
-        <source>Logging started</source>
-        <translation type="vanished">Înregistrearea a pornit</translation>
-    </message>
-    <message>
-        <source>Logging stopped</source>
-        <translation type="vanished">Înregistrarea s-a oprit</translation>
-    </message>
-    <message>
-        <source>Loaded {} freqlogged words</source>
-        <translation type="obsolete">S-au încărcat {} cuvinte freqlogged</translation>
-    </message>
-    <message>
-        <source>Unban {} words</source>
-        <translation type="vanished">Anulează interzicerea a {} cuvinte</translation>
-    </message>
-    <message>
-        <source>Unban one word</source>
-        <translation type="vanished">Anulează interzicerea unui cuvânt</translation>
-    </message>
-    <message>
-        <source>Exported {} words to {}</source>
-        <translation type="vanished">S-au exportat {} cuvinte la {}</translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="82"/>
-        <source>GUI</source>
-        <comment>Start/stop logging</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="83"/>
-        <source>GUI</source>
-        <comment>Quit</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="123"/>
-        <location filename="../nexus/GUI.py" line="177"/>
-        <source>GUI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="131"/>
-        <location filename="../nexus/GUI.py" line="198"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="136"/>
-        <location filename="../nexus/GUI.py" line="194"/>
-        <source>Ban and delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="234"/>
-        <location filename="../nexus/GUI.py" line="624"/>
-        <location filename="../nexus/GUI.py" line="654"/>
-        <location filename="../nexus/GUI.py" line="658"/>
-        <source>GUI</source>
-        <comment>Error</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="235"/>
-        <location filename="../nexus/GUI.py" line="659"/>
-        <source>GUI</source>
-        <comment>Error opening database: {}</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="251"/>
-        <source>GUI</source>
-        <comment>Starting...</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="264"/>
-        <source>GUI</source>
-        <comment>Stop logging</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="266"/>
-        <source>GUI</source>
-        <comment>Logging started</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="268"/>
-        <source>GUI</source>
-        <comment>Stopping...</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="278"/>
-        <source>GUI</source>
-        <comment>Start logging</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="280"/>
-        <source>GUI</source>
-        <comment>Logging stopped</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="335"/>
-        <source>GUI</source>
-        <comment>Loaded {}/{} freqlogged words</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="384"/>
-        <source>GUI</source>
-        <comment>Loaded {}/{} logged chords (no CharaChorder device with chords connected)</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="388"/>
-        <source>GUI</source>
-        <comment>Loaded {}/{} logged chords (+ {} unused chords on device)</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="403"/>
-        <source>GUI</source>
-        <comment>Loaded {}/{} freqlogged words, {}/{} logged chords (no CharaChorder device with chords connected)</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="407"/>
-        <source>GUI</source>
-        <comment>Loaded {}/{} freqlogged words, {}/{} logged chords (+ {} unused chords on device)</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="428"/>
-        <source>GUI</source>
-        <comment>Ban word</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="428"/>
-        <source>GUI</source>
-        <comment>Word to ban:</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="435"/>
-        <location filename="../nexus/GUI.py" line="521"/>
-        <source>GUI</source>
-        <comment>Banned &apos;{}&apos;</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="436"/>
-        <location filename="../nexus/GUI.py" line="522"/>
-        <source>GUI</source>
-        <comment>&apos;{}&apos; already banned</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="454"/>
-        <source>GUI</source>
-        <comment>Unban &apos;{}&apos;?</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="456"/>
-        <source>GUI</source>
-        <comment>Unban {} words?</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="458"/>
-        <source>GUI</source>
-        <comment>Confirm unban</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="464"/>
-        <source>GUI</source>
-        <comment>Unbanned &apos;{}&apos;</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="465"/>
-        <source>GUI</source>
-        <comment>&apos;{}&apos; not banned</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="467"/>
-        <source>GUI</source>
-        <comment>None of the selected words were banned</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="470"/>
-        <source>GUI</source>
-        <comment>Unbanned {}/{} selected words</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="486"/>
-        <location filename="../nexus/GUI.py" line="495"/>
-        <source>GUI</source>
-        <comment>Exported {} entries to {}</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="507"/>
-        <source>GUI</source>
-        <comment>Ban and delete &apos;{}&apos;?</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="510"/>
-        <source>GUI</source>
-        <comment>Ban and delete {} chords?</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="512"/>
-        <source>GUI</source>
-        <comment>Ban and delete {} words?</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="514"/>
-        <source>GUI</source>
-        <comment>Confirm ban</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="525"/>
-        <source>GUI</source>
-        <comment>All of the selected chords were already banned</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="527"/>
-        <source>GUI</source>
-        <comment>All of the selected words were already banned</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="531"/>
-        <source>GUI</source>
-        <comment>Banned and deleted {}/{} selected chords</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="534"/>
-        <source>GUI</source>
-        <comment>Banned and deleted {}/{} selected words</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="548"/>
-        <source>GUI</source>
-        <comment>Delete &apos;{}&apos;?</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="551"/>
-        <source>GUI</source>
-        <comment>Delete {} chords?</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="553"/>
-        <source>GUI</source>
-        <comment>Delete {} words?</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="555"/>
-        <source>GUI</source>
-        <comment>Confirm delete</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="565"/>
-        <source>GUI</source>
-        <comment>Deleted &apos;{}&apos;</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="566"/>
-        <source>GUI</source>
-        <comment>&apos;{}&apos; not found</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="569"/>
-        <source>GUI</source>
-        <comment>None of the selected chords were found</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="571"/>
-        <source>GUI</source>
-        <comment>None of the selected words were found</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="575"/>
-        <source>GUI</source>
-        <comment>Deleted {}/{} selected chords</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="578"/>
-        <source>GUI</source>
-        <comment>Deleted {}/{} selected words</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="583"/>
-        <source>GUI</source>
-        <comment>Database Upgrade</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="586"/>
-        <source>GUI</source>
-        <comment>You are running version {} of nexus, but your database is on version {}.
-Backup your database before pressing &apos;Yes&apos; to upgrade your database, or press &apos;No&apos; to exit without upgrading.</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="600"/>
-        <location filename="../nexus/GUI.py" line="614"/>
-        <source>GUI</source>
-        <comment>Banlist Password</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="601"/>
-        <source>GUI</source>
-        <comment>Choose a new password to encrypt your banlist with:</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="602"/>
-        <source>GUI</source>
-        <comment>Enter your banlist password:</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="607"/>
-        <source>GUI</source>
-        <comment>Password too short</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="609"/>
-        <source>GUI</source>
-        <comment>Password should be at least 8 characters long.
-Continue without securely encrypting your banlist?</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="615"/>
-        <source>GUI</source>
-        <comment>Confirm your banlist password:</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../nexus/GUI.py" line="655"/>
-        <source>GUI</source>
-        <comment>Incorrect password</comment>
-        <translation type="unfinished"></translation>
+        <translation>Primul caracter</translation>
     </message>
 </context>
 <context>
@@ -459,139 +75,114 @@ Continue without securely encrypting your banlist?</comment>
         <translation>Nexus</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="238"/>
+        <location filename="../ui/MainWindow.ui" line="32"/>
         <source>Start logging</source>
         <translation>Începe înregistrarea</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="245"/>
-        <location filename="../ui/MainWindow.ui" line="609"/>
+        <location filename="../ui/MainWindow.ui" line="39"/>
         <source>Refresh</source>
         <translation>Reîmprospătează</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="555"/>
-        <source>File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="562"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="566"/>
-        <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="581"/>
-        <source>Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="584"/>
-        <source>Alt+Q</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="589"/>
-        <source>Nexus Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="594"/>
-        <source>Qt Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="599"/>
-        <source>Platform Default</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="604"/>
+        <location filename="../ui/MainWindow.ui" line="46"/>
         <source>Banlist</source>
         <translation>Listă interziceri</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="614"/>
+        <location filename="../ui/MainWindow.ui" line="53"/>
         <source>Export</source>
         <translation>Exportă</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="267"/>
+        <location filename="../ui/MainWindow.ui" line="67"/>
         <source>Chorded Entry</source>
         <translation type="unfinished">Intrare Chord</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="275"/>
-        <location filename="../ui/MainWindow.ui" line="408"/>
-        <source># shown:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="282"/>
-        <location filename="../ui/MainWindow.ui" line="415"/>
-        <source>Enter 0 to show all entries</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="307"/>
-        <location filename="../ui/MainWindow.ui" line="440"/>
-        <source>Search:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="320"/>
-        <source>Start typing to search for chords...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="375"/>
+        <location filename="../ui/MainWindow.ui" line="110"/>
         <source>Chord</source>
         <translation type="unfinished">Chord</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="380"/>
+        <location filename="../ui/MainWindow.ui" line="115"/>
         <source>Frequency</source>
         <translation>Frecvență</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="385"/>
-        <location filename="../ui/MainWindow.ui" line="528"/>
+        <location filename="../ui/MainWindow.ui" line="120"/>
+        <location filename="../ui/MainWindow.ui" line="184"/>
         <source>Last used</source>
         <translation>Folosit ultima oară</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="400"/>
+        <location filename="../ui/MainWindow.ui" line="131"/>
         <source>Character Entry</source>
         <translation>Intrare caractere</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="453"/>
-        <source>Start typing to search for words...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="508"/>
+        <location filename="../ui/MainWindow.ui" line="174"/>
         <source>Word</source>
         <translation>Cuvânt</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="513"/>
-        <source>Score</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../ui/MainWindow.ui" line="523"/>
+        <location filename="../ui/MainWindow.ui" line="179"/>
         <source>Freq.</source>
         <translation>Frecv.</translation>
     </message>
     <message>
-        <location filename="../ui/MainWindow.ui" line="518"/>
+        <location filename="../ui/MainWindow.ui" line="189"/>
         <source>Avg speed</source>
         <translation>Viteză medie</translation>
+    </message>
+</context>
+<context>
+    <name>GUI</name>
+    <message>
+        <location filename="../src/nexus/GUI.py" line="90"/>
+        <location filename="../src/nexus/GUI.py" line="122"/>
+        <source>Start logging</source>
+        <translation>Începe înregistrarea</translation>
+    </message>
+    <message>
+        <location filename="../src/nexus/GUI.py" line="92"/>
+        <source>Starting...</source>
+        <translation>Se începe...</translation>
+    </message>
+    <message>
+        <location filename="../src/nexus/GUI.py" line="103"/>
+        <source>Stop logging</source>
+        <translation>Oprește înregistrarea...</translation>
+    </message>
+    <message>
+        <location filename="../src/nexus/GUI.py" line="107"/>
+        <source>Logging started</source>
+        <translation>Înregistrearea a pornit</translation>
+    </message>
+    <message>
+        <location filename="../src/nexus/GUI.py" line="126"/>
+        <source>Logging stopped</source>
+        <translation>Înregistrarea s-a oprit</translation>
+    </message>
+    <message>
+        <location filename="../src/nexus/GUI.py" line="159"/>
+				<source>Loaded {} freqlogged words</source>
+				<translation type="unfinished">S-au încărcat {} cuvinte freqlogged</translation>
+    </message>
+    <message>
+        <location filename="../src/nexus/GUI.py" line="222"/>
+				<source>Unban {} words</source>
+				<translation>Anulează interzicerea a {} cuvinte</translation>
+    </message>
+    <message>
+        <location filename="../src/nexus/GUI.py" line="224"/>
+        <source>Unban one word</source>
+        <translation>Anulează interzicerea unui cuvânt</translation>
+    </message>
+    <message>
+        <location filename="../src/nexus/GUI.py" line="240"/>
+				<source>Exported {} words to {}</source>
+				<translation>S-au exportat {} cuvinte la {}</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
In #102, I had added changes to `translations/i18n_ro.ts` as well. This was before the discussion that concluded in not auto-updating this file.

This PR undoes the changes made to this file